### PR TITLE
Remove legacy ENV key value

### DIFF
--- a/Dockerfile.debian11
+++ b/Dockerfile.debian11
@@ -68,8 +68,8 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o 
   curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 
 # setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ARG ROS_DISTRO
 # Environment variables defined using the ENV instruction always override an ARG instruction of the same name. 
 ENV ROS_DISTRO=${ROS_DISTRO:-rolling}
@@ -104,7 +104,7 @@ RUN colcon mixin add default \
   colcon metadata update
 
 # install dependencies via apt
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBCONF_NOWARNINGS=yes
 
 # install and activate ccache, lld, cppcheck
 RUN \
@@ -126,7 +126,7 @@ RUN \
 
 # ---- ROS ----
 # clone source, ROS core
-ENV ROS2_WS /opt/ros2_ws
+ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .

--- a/Dockerfile.debian12
+++ b/Dockerfile.debian12
@@ -66,8 +66,8 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o 
   curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 
 # setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ARG ROS_DISTRO
 # Environment variables defined using the ENV instruction always override an ARG instruction of the same name. 
 ENV ROS_DISTRO=${ROS_DISTRO:-iron}
@@ -105,7 +105,7 @@ RUN colcon mixin add default \
   colcon metadata update
 
 # install dependencies via apt
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBCONF_NOWARNINGS=yes
 
 # install and activate ccache, lld, cppcheck
 RUN \
@@ -119,7 +119,7 @@ RUN \
 
 # ---- ROS ----
 # clone source, ROS core
-ENV ROS2_WS /opt/ros2_ws
+ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .


### PR DESCRIPTION
>  Check warning on line 129 in Dockerfile.debian11
> GitHub Actions
> / build_images_debian11 (humble)
> 
> Legacy key/value format with whitespace separator should not be used
> 
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
> More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/